### PR TITLE
unary-dependent multi-CRFs

### DIFF
--- a/multicrf.py
+++ b/multicrf.py
@@ -14,26 +14,26 @@ import utils
 
 DEPENDENCY_DICTS = {
     "de": {
-        "POS": ["VerbForm", "Case", "PronType", "NumType"],
-        "Case": [],
-        "Number": [],  # missing
-        "Mood": ["Tense"],
-        "Person": ["Polite", "Number[psor]", "VerbForm", "PronType"],
-        "Tense": [],
-        "VerbForm": ["Tense", "Case"],
+        "POS": ["VerbForm"],
+        "Case": ["POS", "VerbForm"],
+        "Number": [],
+        "Mood": [],
+        "Person": ["Polite", "Case"],
+        "Tense": ["Mood", "VerbForm"],
+        "VerbForm": [],
         "Definite": ["PronType"],
-        "PronType": ["NumType"],
+        "PronType": ["Person", "POS"],
         "Degree": ["POS"],
-        "Gender": [],  # missing
-        "Gender[psor]": [],  # missing
-        "Number[psor]": [],
-        "Poss": [],  # missing
-        "NumType": [],
-        "Polarity": [],  # missing
+        "Gender": [],
+        "Gender[psor]": [],
+        "Number[psor]": ["Person"],
+        "Poss": [],
+        "NumType": ["POS", "PronType"],
+        "Polarity": [],
         "Polite": [],
-        "Reflex": [],  # missing
-        "Typo": [],  # missing
-        "Foreign": [],  # missing
+        "Reflex": [],
+        "Typo": [],
+        "Foreign": [],
     }
 }
 

--- a/multicrf.py
+++ b/multicrf.py
@@ -12,6 +12,31 @@ import dataloader
 import models
 import utils
 
+DEPENDENCY_DICTS = {
+    "de": {
+        "POS": ["VerbForm", "Case", "PronType", "NumType"],
+        "Case": [],
+        "Number": [],  # missing
+        "Mood": ["Tense"],
+        "Person": ["Polite", "Number[psor]", "VerbForm", "PronType"],
+        "Tense": [],
+        "VerbForm": ["Tense", "Case"],
+        "Definite": ["PronType"],
+        "PronType": ["NumType"],
+        "Degree": ["POS"],
+        "Gender": [],  # missing
+        "Gender[psor]": [],  # missing
+        "Number[psor]": [],
+        "Poss": [],  # missing
+        "NumType": [],
+        "Polarity": [],  # missing
+        "Polite": [],
+        "Reflex": [],  # missing
+        "Typo": [],  # missing
+        "Foreign": [],  # missing
+    }
+}
+
 
 def main():
 
@@ -23,17 +48,24 @@ def main():
             )
 
         else:
-            tagger_model = models.BiLSTMCRFTagger
+            kwargs = {
+                "tagset_sizes": data_loader.tag_vocab_sizes,
+                "n_layers": args.n_layers,
+                "dropOut": args.dropout,
+                "gpu": args.gpu,
+            }
+            if args.model_name.startswith("unary_dependent"):
+                tagger_model = models.BiLSTMCRFUnaryDependentTagger
+                kwargs["dependency_dict"] = DEPENDENCY_DICTS[args.langs]
+            else:
+                tagger_model = models.BiLSTMCRFTagger
 
             tagger_model = tagger_model(
                 args.emb_dim,
                 args.hidden_dim,
                 len(data_loader.char_to_id),
                 len(data_loader.word_to_id),
-                tagset_sizes=data_loader.tag_vocab_sizes,
-                n_layers=args.n_layers,
-                dropOut=args.dropout,
-                gpu=args.gpu,
+                **kwargs,
             )
         if args.gpu:
             tagger_model = tagger_model.cuda()

--- a/multicrf.py
+++ b/multicrf.py
@@ -34,7 +34,28 @@ DEPENDENCY_DICTS = {
         "Reflex": [],
         "Typo": [],
         "Foreign": [],
-    }
+    },
+    "hi": {
+        "POS": ["Case", "Polite"],  # part of loop
+        "Case": ["VerbForm"],  # part of loop
+        "Gender": [],
+        "Number": [],
+        "Person": ["POS", "Tense", "Case", "Polite"],
+        "AdpType": [],
+        "PronType": ["POS"],
+        "Aspect": ["VerbForm"],
+        "VerbForm": ["Polite", "POS"],  # part of loop
+        "Voice": [],
+        "Mood": ["VerbForm", "POS", "Tense", "Polite"],
+        "Tense": [],
+        "AdvType": [],
+        "NumType": ["POS"],
+        "Polite": [],
+        "Poss": [],
+        "Echo": [],
+        "Polarity": [],
+        "Foreign": [],
+    },
 }
 
 


### PR DESCRIPTION
model can be used by specifying `--model_name unary_dependent`.

The full dependency graph (even for parent-less/child-less nodes) needs to specified in multi_cry.py:DEPENDENCY_DICTS. For now, only the (incomplete) German graph is present. 